### PR TITLE
セキュリティの認証処理を実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,15 +16,15 @@ repositories {
 }
 
 dependencies {
-	//implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
-	//implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.2'
-	//testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/oit/is/z2133/kaizi/janken/controller/JankenController.java
+++ b/src/main/java/oit/is/z2133/kaizi/janken/controller/JankenController.java
@@ -21,7 +21,7 @@ public class JankenController {
    * jankenというGETリクエストがあったら sample21()を呼び出し，sample21.htmlを返す
    */
 
-  @GetMapping("/janken.html")
+  @GetMapping("/janken")
   public String janken1() {
     return "janken.html";
   }

--- a/src/main/java/oit/is/z2133/kaizi/janken/security/JankenAuthConfiguration.java
+++ b/src/main/java/oit/is/z2133/kaizi/janken/security/JankenAuthConfiguration.java
@@ -1,0 +1,48 @@
+package oit.is.z2133.kaizi.janken.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+@EnableWebSecurity
+public class JankenAuthConfiguration {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.formLogin(login -> login
+        .permitAll())
+        .logout(logout -> logout
+            .logoutUrl("/logout")
+            .logoutSuccessUrl("/")) // ログアウト後に / にリダイレクト
+        .authorizeHttpRequests(authz -> authz
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/janken/**")).authenticated() // /janken/以下は認証済みであること
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/**")).permitAll()); // それ以外は全員アクセス可能
+    return http.build();
+  }
+
+  @Bean
+  public InMemoryUserDetailsManager userDetailsService() {
+
+    // ユーザ名，パスワード，ロールを指定してbuildする
+    // このときパスワードはBCryptでハッシュ化されているため，{bcrypt}とつける
+    // ハッシュ化せずに平文でパスワードを指定する場合は{noop}をつける
+    // ハッシュ化されたパスワードを得るには，この授業のbashターミナルで下記のように末尾にユーザ名とパスワードを指定すると良い(要VPN)
+    // $ sshrun htpasswd -nbBC 10 user1 p@ss
+
+    UserDetails user1 = User.withUsername("user1")
+        .password("{bcrypt}$2y$10$bbdzxePs0bGn8rvWk9utjuMlAsBS3E28bKyLIBlg03II6XSkDJAme").roles("USER").build();
+    UserDetails user2 = User.withUsername("user2")
+        .password("{bcrypt}$2y$10$cUgOkuNGZwExnGcRUIwqf.86SiV6Wr3iknNDo7vl7cYbp2N6baoj.").roles("USER").build();
+
+    // 生成したユーザをImMemoryUserDetailsManagerに渡す（いくつでも良い）
+    return new InMemoryUserDetailsManager(user1, user2);
+  }
+
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -3,14 +3,11 @@
 
 <head>
   <meta charset="utf-8">
-  <title>janken</title>
+  <title>Janken</title>
 </head>
 
 <body>
-  <form action="/janken" name="name">
-    <p><input type="text" name="name">
-       <input type="submit" value="入室"></p>
-  </form>
+  <a href="/janken">jankenへのGETをリクエスト</a>
 </body>
 
 </html>


### PR DESCRIPTION
ユーザIDがuser1とuser2のユーザを2名分追加した．ロールはUSERとする。
パスワードはどちらも必ずisdevとし，bcryptでハッシュ化したものを利用する。
http://localhost:8080/にアクセスして表示される「jankenへのGETをリクエスト」をクリックするとログインフォームが表示され，ログインできることを確認した。
